### PR TITLE
New Drainpits algo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Mauro Werder <mauro3@runbox.com>"]
 version = "0.9.0"
 
 [deps]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
@@ -13,8 +14,9 @@ PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 PyPlotExt = "PyPlot"
 
 [compat]
-StaticArrays = "0.11.1, 0.12, 1.0"
+OffsetArrays = "1"
 PyPlot = "2"
+StaticArrays = "0.11.1, 0.12, 1.0"
 julia = "1.9"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,7 @@ authors = ["Mauro Werder <mauro3@runbox.com>"]
 version = "0.9.0"
 
 [deps]
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,10 @@ authors = ["Mauro Werder <mauro3@runbox.com>"]
 version = "0.9.0"
 
 [deps]
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -32,5 +32,5 @@ plotyes && WWF.plt.plotarea(xs, ys, area, pits)
 
 plotyes && WWF.plt.heatmap(xs, ys, c)
 
-demf = WWF.fill_dem(dem, pits, dir) #, small=1e-6)
+demf = WWF.fill_dem(dem, sinks, dir) #, small=1e-6)
 plotyes && WWF.plt.heatmap(xs, ys, demf.-dem)

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -24,7 +24,7 @@ ys = -0.5:dx:3.0
 dem = ele.(xs, ys', randfac=0.1, withpit=true);
 plotyes && WWF.plt.heatmap(xs, ys, dem)
 
-area, slen, dir, nout, nin, pits, c, bnds  = WWF.waterflows(dem, drain_pits=true);
+area, slen, dir, nout, nin, sinks, pits, c, bnds  = WWF.waterflows(dem, drain_pits=true);
 
 @assert size(dem)==(length(xs), length(ys))
 plotyes && WWF.plt.plotit(xs, ys, dem)

--- a/examples/subglacial-routing.jl
+++ b/examples/subglacial-routing.jl
@@ -46,13 +46,13 @@ g = 9.81 # accel. due to gravity
 phi = bed + flotation_fraction * rho_i/rho_w * (surface - bed)
 
 # Route the water
-area, slen, dir, nout, nin, pits, c, bnds  = WWF.waterflows(phi, drain_pits=true)
+area, slen, dir, nout, nin, sinks, pits, c, bnds  = WWF.waterflows(phi, drain_pits=true)
 
 # Plot it
 plotyes && WWF.plt.plotit(x, y, phi)
-plotyes && WWF.plt.plotarea(x, y, area, pits)
+plotyes && WWF.plt.plotarea(x, y, area, sinks)
 
 plotyes && WWF.plt.heatmap(x, y, c)
 
-phi_filled = WWF.fill_dem(phi, pits, dir) #, small=1e-6)
+phi_filled = WWF.fill_dem(phi, sinks, dir) #, small=1e-6)
 plotyes && WWF.plt.heatmap(x, y, phi_filled .- phi)

--- a/ext/PyPlotExt.jl
+++ b/ext/PyPlotExt.jl
@@ -32,11 +32,10 @@ function plotit(x, y, waterflows_output::Tuple, dem)
     plotdir(x, y, dir)
 end
 
-function plotdir(x, y, dir)
+function plotdir(x, y, dir; f = 200)
     vecfield = WWF.dir2vec.(dir)
     vecfieldx = [v[1] for v in vecfield]
     vecfieldy = [v[2] for v in vecfield]
-    f = 200
     quiver(repeat(x,1, length(y)), repeat(y,length(x),1), vecfieldx, vecfieldy, scale_units="width", scale=f)
 end
 

--- a/ext/PyPlotExt.jl
+++ b/ext/PyPlotExt.jl
@@ -33,7 +33,7 @@ function plotit(x, y, waterflows_output::Tuple, dem)
 end
 
 function plotdir(x, y, dir)
-    vecfield = WWF.dir2vec.(dir)
+    vecfield = WWF.dir2vec.(dir, true)
     vecfieldx = [v[1] for v in vecfield]
     vecfieldy = [v[2] for v in vecfield]
     quiver(repeat(x,1, length(y)), repeat(y,length(x),1), vecfieldx, vecfieldy)
@@ -78,8 +78,8 @@ function plotbnds(x,y,bnds)
 end
 
 function plotlakedepth(x, y, dem)
-    area, slen, dir, nout, nin, pits  = waterflows(dem)
-    demf = WWF.fill_dem(dem, pits, dir)
+    area, slen, dir, nout, nin, sinks, pits  = waterflows(dem)
+    demf = WWF.fill_dem(dem, sinks, dir)
     heatmap(x, y, demf.-dem)
 end
 

--- a/ext/PyPlotExt.jl
+++ b/ext/PyPlotExt.jl
@@ -33,10 +33,11 @@ function plotit(x, y, waterflows_output::Tuple, dem)
 end
 
 function plotdir(x, y, dir)
-    vecfield = WWF.dir2vec.(dir, true)
+    vecfield = WWF.dir2vec.(dir)
     vecfieldx = [v[1] for v in vecfield]
     vecfieldy = [v[2] for v in vecfield]
-    quiver(repeat(x,1, length(y)), repeat(y,length(x),1), vecfieldx, vecfieldy)
+    f = 200
+    quiver(repeat(x,1, length(y)), repeat(y,length(x),1), vecfieldx, vecfieldy, scale_units="width", scale=f)
 end
 
 pits2inds(pits) = ([p.I[1] for p in pits],

--- a/src/WhereTheWaterFlows.jl
+++ b/src/WhereTheWaterFlows.jl
@@ -51,13 +51,13 @@ ind2dir(ind::CartesianIndex) = dirnums[ind + I22]
 Translate a D8 direction number into a CartesianIndex (i.e. a flow vector).
 Maps dir==BARRIER and dir==SINK to CartesianIndex(0,0) also.
 """
-function dir2ind(dir)
-    dir==BARRIER && error("Cannot make CartisianIndex for BARRIER")
-    return dir==SINK ? CartesianIndex(0,0) : cartesian[dir]
+function dir2ind(dir, allow_BARRIER=false)
+    allow_BARRIER==false && dir==BARRIER && error("Cannot make CartisianIndex for BARRIER")
+    return (dir==SINK || dir==BARRIER) ? CartesianIndex(0,0) : cartesian[dir]
 end
 
 "Translate a D8 direction number into a 2D vector."
-dir2vec(dir) = [dir2ind(dir).I...]
+dir2vec(dir, allow_BARRIER=false) = [dir2ind(dir, allow_BARRIER).I...]
 
 """
 Tests whether a cell `J` with flowdir `dirJ` flows into cell `I`.

--- a/src/WhereTheWaterFlows.jl
+++ b/src/WhereTheWaterFlows.jl
@@ -92,6 +92,7 @@ Return
 - nout - number of outflow cells of a cell (0 or 1)
 - nin  - number of inflow cells of a cell (0-8)
 - pits - location of pits as a `Vector{CartesianIndex{2}}` (sorted)
+- dem - DEM, unchanged
 - flowdir_extra_output -- nothing (not used by this function)
 """
 function d8dir_feature(dem, bnd_as_pits)
@@ -362,10 +363,9 @@ function _prune_boundary!(del, bnds, catchments::AbstractMatrix, color, colormap
 end
 
 """
-     drainpits!(dir, nin, nout, pits, c, bnds, dem;
-               maxiter=100)
+     drainpits!(dir, nin, nout, pits, c, bnds, dem)
 
-Return an updated direction field which drains (interior) pits.
+Update in place the direction field such that it drains (interior) pits.
 This is done by reversing the flow connecting the lowest point on the catchment boundary
 to the pit for each catchment.
 
@@ -373,12 +373,12 @@ There needs to be a decision on how to treat the outer boundary and boundaries
 to NaN-cells.  Possibilities:
 - do not treat boundary cells as pits but do treat pits at the boundary as terminal.
 - treat boundary cells as pits, i.e. flow reaching such a cell will vanish.  Again
-  such cells would be terminal.  This is currently done
+  such cells would be terminal.  This is currently done.
 
 TODO: What to do if there are no terminal pits in the DEM?  Fill to the uppermost pit?  Or take
 the lowermost as terminal? -> currently it picks a random one
 
-Returns new dir, nin, nout, pits (sorted), c, bnds
+Update in place dir, nin, nout, pits (sorted), c, bnds
 
 TODO: this is the performance bottleneck.
 """

--- a/src/WhereTheWaterFlows.jl
+++ b/src/WhereTheWaterFlows.jl
@@ -1,6 +1,7 @@
 # TODO:
 # - check with GRF that it works most of the time
 # - better barrier breach algo: select point which has minimal elevation of Imin and target
+#   --> what if DEM has a spillway which is a flat area?  Then this method will fail!
 # - deinstall packages: Infiltrator, Primes, FFTW
 
 module WhereTheWaterFlows
@@ -28,9 +29,9 @@ Note, I use the conversion that the x-axis corresponds to the row of
 the matrix and the y-axis the columns.  To print them in this "normal"
 coordinate system use `showme`
 """
-const dirnums = SMatrix{3,3}(reverse([ 7      8 9
-                                       4 PIT 6
-                                       1      2 3]',
+const dirnums = SMatrix{3,3}(reverse([ 7   8  9
+                                       4  PIT 6
+                                       1   2  3]',
                                      dims=2))
 
 "Translation from dirnums to CartesianIndex"
@@ -271,7 +272,7 @@ Note: this function may cause a stackoverflow on very big catchments.
 function flowrouting_catchments(dir, sinks, pits, cellarea, feedback_fn, stacksize) # on linux standard is 2^13 * 2^10
     c = fill!(similar(dir, Int), 0) # catchment color of BARRIER is 0
     slen = fill!(similar(dir, Int), 0)
-    np = length(pits)
+ @show   np = length(pits)
     # Some setup to allow both array and tuple-of-array inputs for cellarea and feedback_fn:
     area = init_area(dir, cellarea) # (matrix,) or tuple of matrices
     cellarea_ = cellarea isa Tuple ? cellarea : (cellarea, )
@@ -294,13 +295,13 @@ function flowrouting_catchments(dir, sinks, pits, cellarea, feedback_fn, stacksi
             stacksize) ))
     end
     for color in axes(pits)[1]
-        pit = pits[color]
+       pit = pits[color]
 
         # This is a dirty trick to increase the call-stack size
         # https://stackoverflow.com/questions/71956946/how-to-increase-stack-size-for-julia-in-windows
         # Note that stacksize is a undocumented argument of Task!
         wait(schedule( Task(() -> _flowrouting_catchments!(area, slen, c, dir, cellarea_, feedback_fn_, color, pit),
-            stacksize) ))
+                            stacksize) ))
     end
     # unwrap tuple if cellarea was not a tuple:
     if !(cellarea isa Tuple)
@@ -705,16 +706,20 @@ function drainpits2!(dir, nin, nout, sinks, pits, c, bnds, dem)
     npits = length(pits)
     ncolors = nsinks + npits
 
+    tmp = eltype(pits)[]
+    sizehint!(tmp, npits÷4)
+    new_pits = Origin(nsinks+1)(tmp) # when two re-directed branches meet at a spillway,
+                             # they create a new pit at the spillway
+
+
     maxiter = 100
     Iend = CartesianIndex(size(dem))
 
     dirty_catchment = falses(nsinks+npits)
-    pits_to_delete = Origin(nsinks+1)(falses(length(pits)))
+    # pits_to_delete = Origin(nsinks+1)(falses(length(pits)))
 
     for pit_color in axes(pits)[1]
         P = pits[pit_color]
-        # dirty catchments cannot be processed in this round, but need to wait for the next iteration
-        dirty_catchment[pit_color] && continue
 
         # If there are no boundaries for this point error
         isempty(bnds[pit_color]) && error("Found a pit-catchment which has no outflow.  If this is intended consider setting the DEM-cell to a NaN at $P and setting nan_as_sink.")
@@ -747,19 +752,41 @@ function drainpits2!(dir, nin, nout, sinks, pits, c, bnds, dem)
                 spillway = spillway_I
             end
         end
+        # potentially adjust P_i such that it is lowestmost cell bordering on P_o
+        ele_min = typemax(eltype(dem))
+        for J in iterate_D9(P_o, dem)
+            P_o==J && continue # do not look at the cell itself
+            c[J] == 0 && continue # J is a BARRIER cell
+            c[J]!=c[P_i] && continue # J is not in P_i's catchment
+            if dem[J] < ele_min
+                ele_min = dem[J]
+                P_i = J
+            end
+        end
 
         if c[P_o]>nsinks
-            # if the target is in a pit-catchment, mark that pit-catchment as dirty
+            # if the other catchment is in a pit-catchment, mark it dirty
             dirty_catchment[c[P_o]] = true
         end
 
-        # Reverse directions on path going from P_i to P
+        # if P∈[CartesianIndex(9,37), CartesianIndex(14,37), CartesianIndex(8,33)]
+        #     @infiltrate
+        # end
+
+        # Reverse directions on path going from P_i to P and
+        # create flow from P_i to P_o (i.e. across the spillway)
         P1 = P_i
-        P2 = P_i + dir2ind(dir[P_i]) # do lookup ahead of:
+        P2 = P_i + dir2ind(dir[P_i]) # do lookup ahead of re-direction
         if flowsinto(P_o, dir[P_o], P_i)
-            @infiltrate
+            # This means this spillway was already used from the other side.
+            # This means a new pit is created at the spillway.
+            @assert dirty_catchment[c[P_o]]
+            push!(new_pits, P_o)
+            allow_P_o_pit = true
+        else
+            allow_P_o_pit = false
         end
-        _flow_from_to!(P_i, P_o, dir, nin, nout) # first, do the flow across the boundary
+        _flow_from_to!(P_i, P_o, dir, nin, nout, allow_P_o_pit) # first, do the flow across the boundary
         while P1!=P
             # get down-downstream point (do ahead lookup as a undisturbed dir is needed)
             P_next = P2 + dir2ind(dir[P2])
@@ -768,14 +795,14 @@ function drainpits2!(dir, nin, nout, sinks, pits, c, bnds, dem)
 
             P1,P2 = P2,P_next
         end
-        pits_to_delete[pit_color] = true
+        #pits_to_delete[pit_color] = true
     end
     # update pits
-    deleteat!(no_offset_view(pits), no_offset_view(pits_to_delete))
+    #deleteat!(no_offset_view(pits), no_offset_view(pits_to_delete))
 
     # bnds is now invalid
     empty!(bnds)
-    return nothing
+    return new_pits
 end
 
 function drainpits2_old!(dir, nin, nout, sinks, pits, c, bnds, dem)

--- a/src/postproc.jl
+++ b/src/postproc.jl
@@ -132,11 +132,14 @@ end
 Fill the pits of a DEM (apply this after applying "drainpits",
 which is done by default in `waterflows`). Returns the filled DEM.
 
-Note, this is *not* needed as pre-processing step to use the flow-routing
-function `waterflows`.
-
-This uses a tree traversal to fill the DEM. It does it depth-first (as it
-is easier) which may lead to a stack overflow on a large DEM.
+Notes:
+- this is *not* needed as pre-processing step to use the flow-routing
+  function `waterflows`.
+- routing on a filled DEM will not produce exactly the same flow pattern: on
+  the shores of lakes streams which entered the lake can now go the other way.
+  I suspect on most DEMs the differences will be very minimal.
+- This uses a tree traversal to fill the DEM. It does it depth-first (as it
+  is easier) which may lead to a stack overflow on a large DEM.
 """
 function fill_dem(dem, sinks, dir; small=0)
     dem = copy(dem)
@@ -150,9 +153,9 @@ end
 # which has lower elevation than the previous one, it will set that point's elevation
 # and all upstream points' elevation the elevation of the first point.
 function _fill_ij!(ele, dem, ij, dir, small)
-    if ele > dem[ij]
+    if ele >= dem[ij]
+        ele += 2*eps(ele)
         dem[ij] = ele
-        ele += small
     else
         ele = dem[ij]
     end

--- a/src/postproc.jl
+++ b/src/postproc.jl
@@ -9,7 +9,7 @@ Sets all catchments which are smaller than minsize to `val` (=0).
 Catchments with number <1 are ignored.
 
 Note that, as the catchments are re-numbered, the number will not correspond
-to the pits anymore.
+to the sinks and pits anymore.
 """
 function prune_catchments(catchments, minsize; val=0)
     c = copy(catchments)
@@ -38,16 +38,14 @@ end
 
 
 """
-    catchment(dir, ij, dem=nothing)
+    catchment(dir, ij)
 
-Calculates the catchment of one or several grid-point ij.  If desired, its
+Calculates the catchment of one or several grid-point(s) ij.  If desired, the catchment
 boundary can be calculated with `make_boundaries([c], [1])`.
 
 Input
 - dir -- direction field
 - ij -- index of the point (2-Tuple, or CartesianIndex) or a Vector{CartesianIndex} for several
-- dem -- if supplied, then its NaN-points will not be considered. NOTE: this slow down the calculation
-         by potentially a large amount!
 
 Returns
 - catchment -- BitArray
@@ -57,28 +55,20 @@ Tip: only being off by one grid-point can make the difference
 
 See also: `catchments`
 """
-catchment(dir, ij::Tuple, dem=nothing) = catchment(dir, CartesianIndex(ij...), dem)
-function catchment(dir, ij::CartesianIndex, dem=nothing)
+catchment(dir, ij::Tuple) = catchment(dir, CartesianIndex(ij...))
+function catchment(dir, ij::CartesianIndex)
     # c = fill!(similar(dir, Bool), false) # makes Matrix{Bool}
     c = fill!(similar(BitArray, axes(dir)), false) # makes BitMatrix
     # recursively traverse the drainage tree in up-flow direction,
     # starting at ij
     _catchment!(c, dir, ij)
-    if dem!==nothing
-        # TODO: this is very non-performant
-        c[isnan.(dem)] .= false
-    end
     return c
 end
-function catchment(dir, ijs::Union{<:Array{CartesianIndex{2}}, CartesianIndices{2}}, dem=nothing)
+function catchment(dir, ijs::Union{<:Array{CartesianIndex{2}}, CartesianIndices{2}})
     #c = fill!(similar(dir, Bool), false) # makes Matrix{Bool}
     c = fill!(similar(BitArray, axes(dir)), false) # makes BitMatrix
     for ij in ijs
         _catchment!(c, dir, ij)
-    end
-    if dem!==nothing
-        # TODO: this is very non-performant
-        c[isnan.(dem)] .= false
     end
     return c
 end
@@ -87,7 +77,7 @@ function _catchment!(c, dir, ij)
     # proc upstream points
     for IJ in iterate_D9(ij, c)
         ij==IJ && continue
-        c[IJ] && continue # this hits a point which is already in the catchment,
+        c[IJ] && continue # this hits a point which is already processed,
                           # thus nothing more to do
         if flowsinto(IJ, dir[IJ], ij)
             _catchment!(c, dir, IJ)
@@ -113,8 +103,7 @@ Make a map of catchments from different (non-overlapping) sinks.
 
 See also: `catchment`
 """
-function catchments(dir, sinks::Union{Vector{Vector{CartesianIndex{2}}}, Vector{<:CartesianIndices{2}}},
-                    dem=nothing;
+function catchments(dir, sinks::Union{Vector{Vector{CartesianIndex{2}}}, Vector{<:CartesianIndices{2}}};
                     check_sinks_overlap=true)
 
     ncs = length(sinks)
@@ -131,17 +120,17 @@ function catchments(dir, sinks::Union{Vector{Vector{CartesianIndex{2}}}, Vector{
     @assert ncs<255 "More than 255 sinks not supported (yet)." # then use something else than UInt8
     out = fill!(similar(dir, UInt8), 0)
     for (i,s) in enumerate(sinks)
-        c = catchment(dir, s, dem)
+        c = catchment(dir, s)
         out += c*i
     end
     return out
 end
 
 """
-    fill_dem(dem, pits, dir)
+    fill_dem(dem, sinks, dir; small=0)
 
-Fill the pits (aka sinks) of a DEM (apply this after applying "drainpits",
-which is the default). Returns the filled DEM.
+Fill the pits of a DEM (apply this after applying "drainpits",
+which is done by default in `waterflows`). Returns the filled DEM.
 
 Note, this is *not* needed as pre-processing step to use the flow-routing
 function `waterflows`.
@@ -149,10 +138,10 @@ function `waterflows`.
 This uses a tree traversal to fill the DEM. It does it depth-first (as it
 is easier) which may lead to a stack overflow on a large DEM.
 """
-function fill_dem(dem, pits, dir; small=0.0)
+function fill_dem(dem, sinks, dir; small=0)
     dem = copy(dem)
-    Threads.@threads for pit in pits
-        _fill_ij!(-Inf, dem, pit, dir, small)
+    Threads.@threads for sink in sinks
+        _fill_ij!(-Inf, dem, sink, dir, small)
     end
     return dem
 end

--- a/test/postproc.jl
+++ b/test/postproc.jl
@@ -4,11 +4,12 @@
     xs = -1.5:dx:1
     ys = -0.5:dx:3.0
     dem = dem1.(xs, ys', withpit=true)
-    area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, bnd_as_pits=false)
+    area, slen, dir, nout, nin, sinks, pits, c, bnds = WWF.waterflows(dem, bnd_as_sink=true)
     demf = WWF.fill_dem(dem, pits, dir)
     @test sum(demf.-dem) ≈ 2.1499674517313414
     @test sum(demf.-dem .> 0) == 5
-    @test all([c[pits[cc]]==cc  for cc=1:length(pits)]) # pit in catchment of same color
+    @test all([c[pits[cc]]==cc  for cc=axes(pits)[1]]) # pit in catchment of same color
+    @test all([c[sinks[cc]]==cc  for cc=axes(sinks)[1]]) # sink in catchment of same color
 end
 
 @testset "catchment" begin
@@ -17,7 +18,7 @@ end
         ys = xs
 
         @test size(dem)==(length(xs), length(ys))
-        area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem);
+        area, slen, dir, nout, nin, sinks, pits, c, bnds = WWF.waterflows(dem);
 
         for cc=1:length(pits)
             ij = pits[cc]

--- a/test/postproc.jl
+++ b/test/postproc.jl
@@ -5,7 +5,7 @@
     ys = -0.5:dx:3.0
     dem = dem1.(xs, ys', withpit=true)
     area, slen, dir, nout, nin, sinks, pits, c, bnds = WWF.waterflows(dem, bnd_as_sink=true)
-    demf = WWF.fill_dem(dem, pits, dir)
+    demf = WWF.fill_dem(dem, sinks, dir)
     @test sum(demf.-dem) ≈ 2.1499674517313414
     @test sum(demf.-dem .> 0) == 5
     @test all([c[pits[cc]]==cc  for cc=axes(pits)[1]]) # pit in catchment of same color

--- a/test/postproc.jl
+++ b/test/postproc.jl
@@ -7,7 +7,7 @@
     area, slen, dir, nout, nin, sinks, pits, c, bnds = WWF.waterflows(dem, bnd_as_sink=true)
     demf = WWF.fill_dem(dem, sinks, dir)
     @test sum(demf.-dem) ≈ 2.1499674517313414
-    @test sum(demf.-dem .> 0) == 5
+    @test sum(demf.-dem .> 0) == 40
     @test all([c[pits[cc]]==cc  for cc=axes(pits)[1]]) # pit in catchment of same color
     @test all([c[sinks[cc]]==cc  for cc=axes(sinks)[1]]) # sink in catchment of same color
 end

--- a/test/postproc.jl
+++ b/test/postproc.jl
@@ -10,6 +10,10 @@
     @test sum(demf.-dem .> 0) == 40
     @test all([c[pits[cc]]==cc  for cc=axes(pits)[1]]) # pit in catchment of same color
     @test all([c[sinks[cc]]==cc  for cc=axes(sinks)[1]]) # sink in catchment of same color
+
+    area2 = WWF.waterflows(dem, bnd_as_sink=true)[1]
+    lakes = demf.>dem
+    @test area[.!lakes]==area2[.!lakes]
 end
 
 @testset "catchment" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,6 +202,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=false);
     #plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 6
+    @test sum(dir.==5) == length(pits)
     @test maximum(slen)==86
     @test maximum(area)==4759
     @test length(unique(c))==6
@@ -232,6 +233,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=false);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 7
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test maximum(slen)==87
     @test maximum(area[.!isnan.(area)])==4725
     @test length(unique(c))==8
@@ -244,6 +246,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=true);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 408
+    @test sum(dir.==5) - sum(isnan.(dem)) + 10 == length(pits) # +10 is because some NaN-cells become pits as bnd_as_pits=true
     @test maximum(slen)==66
     @test maximum(area[.!isnan.(area)])==4457
     @test length(unique(c))==409
@@ -257,6 +260,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=false);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 4
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test maximum(slen)==142
     @test maximum(area[.!isnan.(area)])==7706
     @test length(unique(c))==5
@@ -270,6 +274,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 406
+    @test sum(dir.==5) - sum(isnan.(dem)) + 10 == length(pits) # +10 is because some NaN-cells become pits as bnd_as_pits=true
     @test maximum(slen)==75
     @test maximum(area[.!isnan.(area)])==4458
     @test length(unique(c))==407
@@ -289,6 +294,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=false);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 6
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test maximum(slen)==84
     @test maximum(area[.!isnan.(area)])==4658
     @test length(unique(c))==7
@@ -300,6 +306,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=true);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 390
+    @test sum(dir.==5) - 8 == length(pits)
     @test maximum(slen)==64
     @test maximum(area[.!isnan.(area)])==4434
     @test length(unique(c))==391
@@ -311,6 +318,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=false);
     #plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 1
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test maximum(slen)==195
     @test maximum(area[.!isnan.(area)])==9605
     @test length(unique(c))==2
@@ -323,6 +331,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true);
     # plotarea_dem(xs, ys, dem, area, pits)
     @test length(pits) == 388
+    @test sum(dir.==5) - 8 == length(pits)
     @test maximum(slen)==81
     @test maximum(area[.!isnan.(area)])==4978
     @test length(unique(c))==389
@@ -341,6 +350,7 @@ end
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=false)
     @test mask[pits[1]]
     @test length(pits)==1
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test all([c[pits[cc]]==cc  for cc=1:length(pits)]) # pit in catchment of same color
     #@test all(getindex.(Ref(mask), pits).==0) # tests that there are no interior pits left
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true)
@@ -355,6 +365,7 @@ end
     @test mask[pits[1]]
     @test mask[pits[2]]
     @test length(pits)==2
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test all([c[pits[cc]]==cc  for cc=1:length(pits)]) # pit in catchment of same color
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true)
     @test all(getindex.(Ref(mask), pits).==0)
@@ -366,6 +377,7 @@ end
     #should not error
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=false)
     @test length(pits)==2
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test all([c[pits[cc]]==cc  for cc=1:length(pits)]) # pit in catchment of same color
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true)
     @test all(getindex.(Ref(mask), pits).==0)
@@ -379,6 +391,7 @@ end
     mask[1,:] .= false; mask[end,:] .= false; mask[:,1] .= false; mask[:,end] .= false
     # should not have a pit in the interior
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=false)
+    @test sum(dir.==5) - sum(isnan.(dem)) == length(pits)
     @test all(getindex.(Ref(mask), pits).==0)
     @test all([c[pits[cc]]==cc  for cc=1:length(pits)]) # pit in catchment of same color
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true)
@@ -405,6 +418,7 @@ end
     stacksize = 2^13 * 2^10
     area, slen, c = WWF.flowrouting_catchments(dir, pits, ones(size(dem)), nothing, stacksize)
     @test sum(c.==0) == 42 # these are bongous...
+    @test sum(dir.==5) - 8 == length(pits)
 
     area_flow, dir_flow = WWF.waterflows(dem, drain_pits=true, bnd_as_pits=true)[[1,3]];
     @test sum(area.!=area_flow) == 79
@@ -421,6 +435,7 @@ end
     bnds2 = WWF.make_boundaries(c, 1:length(pits))
 
     @test sort(sort.(bnds))==sort(sort.(bnds2))
+    @test sum(dir.==5) - 8 == length(pits)
 end
 
 @testset "cellarea" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,19 +400,19 @@ end
     @test all([c[pits[cc]]==cc  for cc=1:length(pits)]) # pit in catchment of same color
 end
 
-@testset "NOFLOWer" begin
+@testset "BARRIER" begin
     xs, dem = peaks2_nan_edge()
     ys = xs
 
     area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=true);
     @test sum(c.==0) == 8
-    # add a NOFLOWer cell
+    # add a BARRIER cell
     # (Note: this will not be consistent with the routing
-    # (i.e. flow is still into NOFLOWer, i.e. NOFLOWer should be a pit) and thus
+    # (i.e. flow is still into BARRIER, i.e. BARRIER should be a pit) and thus
     # leads to bongous results.  Well, let's just test the bongous results anyway,
     # to make sure they stay the same bongous.)
     ind = CartesianIndex(43,30)
-    dir[ind] = WWF.NOFLOWer
+    dir[ind] = WWF.BARRIER
     # and drain the pits
     WWF.drainpits!(dir, nin, nout, pits, c, bnds, dem)
     stacksize = 2^13 * 2^10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -411,6 +411,18 @@ end
     @test sum(dir.!=dir_flow) == 1
 end
 
+@testset "drainpits" begin
+    xs, dem = peaks2_nan_edge()
+    ys = xs
+
+    area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_pits=true);
+    WWF.drainpits!(dir, nin, nout, pits, c, bnds, dem)
+    area, slen, c = WWF.flowrouting_catchments(dir, pits, fill!(similar(dem),1), nothing, 2^13 * 2^10)
+    bnds2 = WWF.make_boundaries(c, 1:length(pits))
+
+    @test sort(sort.(bnds))==sort(sort.(bnds2))
+end
+
 @testset "cellarea" begin
     dx = 0.9
     xs = -1.5:dx:1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -487,18 +487,18 @@ end
     @test area[2] == [11.0 11.0 47.0 23.0; 11.0 11.0 11.0 11.0; 62.0 36.0 23.0 11.0]
 end
 
-"Potentially pathological function for call depth"
-function ramp(l,w)
-    y=-w:w
-    x=1:l
-    dem = (1 .+ y.^2) .* x'.*0.00001
-    return x,y,dem
-end
-@testset "stackoverflow" begin
-    x,y,dem = ramp(10^4,3);
-    waterflows(dem, drain_pits=false); # no error
-    @test_throws TaskFailedException waterflows(dem, drain_pits=false, stacksize=1000) # inside it's a StackOverflowError
-end
+# "Potentially pathological function for call depth"
+# function ramp(l,w)
+#     y=-w:w
+#     x=1:l
+#     dem = (1 .+ y.^2) .* x'.*0.00001
+#     return x,y,dem
+# end
+# @testset "stackoverflow" begin
+#     x,y,dem = ramp(10^4,3);
+#     waterflows(dem, drain_pits=false); # no error
+#     @test_throws TaskFailedException waterflows(dem, drain_pits=false, stacksize=1000) # inside it's a StackOverflowError
+# end
 
 #################################
 include("postproc.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,10 +175,10 @@ end
     dem = ones(4,4)
     dem[2,2] = 0.5
     dem[2,3] = 0.45
-    area, slen, dir, nout, nin, pits, c, bnds = WWF.waterflows(dem);
+    dir = WWF.d8dir_feature(dem, true, true)[1]
     @test dir==[10  10  10  10
-                10  8  1  10
-                10  4  4  10 # without adjustment this row would be '10  7  4  10'
+                10   8   5  10
+                10   4   4  10 # without adjustment this row would be '10  7  4  10'
                 10  10  10  10]
 end
 
@@ -272,10 +272,10 @@ end
     @test length(sinks) == 414
     @test sum(dir.==11) - sum(isnan.(dem)) == 0
     @test sum(dir.==5)  == length(pits)
-    @test maximum(slen)==75
+    @test maximum(slen)==91
     @test maximum(area[.!isnan.(area)])==4458
     @test length(unique(c))==415
-    @test sum(c) == 2105520
+    @test sum(c) == 2109977
     @test sum(diff(c[:])) == 413
     @test sort(unique(c))[[1,end]] ==[0,414]
     @test length(bnds)==0
@@ -425,9 +425,6 @@ end
     area, slen, dir, nout, nin, sinks, pits, c, bnds = WWF.waterflows(dem, drain_pits=false, bnd_as_sink=true);
     WWF.drainpits!(dir, nin, nout, sinks, pits, c, bnds, dem)
     area, slen, c = WWF.flowrouting_catchments(dir, sinks, pits, fill!(similar(dem),1), nothing, 2^13 * 2^10)
-    bnds2 = WWF.make_boundaries(c, 1:length(pits))
-
-    @test sort(sort.(bnds))==sort(sort.(bnds2))
     @test sum(dir.==5) == length(pits)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,11 @@ using Test
 # test examples
 module Test_Examples # use a module to avoid name-space pollution
 plotyes = false
-for fl in readdir("../examples/")
-    isfile(fl) && include(joinpath("../examples/", fl))
+println("Running examples:")
+for fl in readdir("../examples/", join=true)
+    isfile(fl) || continue
+    println(fl)
+    include(fl)
 end
 end
 
@@ -501,4 +504,4 @@ end
 end
 
 #################################
-#include("postproc.jl")
+include("postproc.jl")


### PR DESCRIPTION
Perf improvements are ok:

On master 24a938467957587b2de222434122 (seems to scale roughly as dof^2)
```
size(dem) = (1768, 2475)
 24.184546 seconds (9.74 M allocations: 1.362 GiB, 1.27% gc time)

size(dem) = (2501, 3501)
 90.270202 seconds (20.45 M allocations: 2.835 GiB, 1.03% gc time, 0.74% compilation time)

size(dem) = (3572, 5001)
369.134222 seconds (39.85 M allocations: 5.763 GiB, 0.69% gc time)
```

This PR (seems to scale roughly linearly with dof)
```
size(dem) = (1768, 2475)
  4.662908 seconds (9.30 M allocations: 1.318 GiB, 0.63% gc time)

size(dem) = (2501, 3501)
  9.670854 seconds (18.67 M allocations: 2.682 GiB, 6.49% gc time)

size(dem) = (3572, 5001)
 21.115851 seconds (38.14 M allocations: 5.534 GiB, 8.55% gc time)

size(dem) = (5001, 7001)                                                                        
 46.553710 seconds (74.83 M allocations: 10.953 GiB, 13.48% gc time)                            

size(dem) = (10001, 14001)
243.772434 seconds (299.55 M allocations: 44.433 GiB, 38.09% gc time)
```

With a DEM with LOTS of pits:
```
using WhereTheWaterFlows
if !(@isdefined WWF)
    const WWF = WhereTheWaterFlows
end

"An artificial DEM"
function ele(x, y; withpit=false, randfac=0.0)
    out = - (x^2 - 1)^2 - (x^2*y - x - 1)^2 + 6 + 0.1*x + 3*y
    if withpit
        out -= 2*exp(-(x^2 + y^2)*50)
    end
    out += randfac*randn()
    return out<0 ? 0.0 : out
end
dx = 0.001*0.7
xs = -1.5:dx:1
ys = -0.5:dx:3.0
dem = ele.(xs, ys', randfac=0.1, withpit=true);
@show size(dem)
@time area, slen, dir, nout, nin, sinks, pits, c, bnds  = WWF.waterflows(dem, drain_pits=true);
```

This is on top of PR #29 
