### PR TITLE
improve (minor) subglacial routing documentation

### DIFF
--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -15,6 +15,12 @@ Raess, L., Kolyukhin, D., and Minakov, A. (2019): Efficient parallel random
 field generator for large 3-D geophysical problems. Computers & Geosciences,
 131, 158-169. DOI: [10.1016/j.cageo.2019.06.007](https://doi.org/10.1016/j.cageo.2019.06.007)
 
+## Subglacial flow method
+
+Shreve, R. L. (1972): Movement of water in glaciers. Journal of Glaciology, 11(62), 205-214. DOI: [10.3189/S002214300002219X](https://doi.org/10.3189/S002214300002219X)
+
+Röthlisberger, H. (1972): Water pressure in intra-and subglacial channels. Journal of Glaciology, 11(62), 177-203. DOI:[10.3189/S0022143000022188](https://doi.org/10.3189/S0022143000022188)
+
 ## Applications using WhereTheWaterFlows
 
 Malczyk, G., Gourmelen, N., Werder, M., Wearing, M., and Goldberg, D. (2023):

--- a/docs/src/subglacially.md
+++ b/docs/src/subglacially.md
@@ -10,8 +10,8 @@ Compared with plain `waterflows`, it provides:
 - optional per-sink flux aggregation.
 
 This module is aimed at routing water under ice using the Shreve hydraulic
-potential.  Optionally, pressure-melting-point effects (the Röthlisberger
-deflection) are accounted for.
+potential (Shreve, 1972).  Optionally, pressure-melting-point effects (the Röthlisberger
+deflection) are accounted for (Röthlisberger, 1972).
 
 Recent applications using this workflow include Malczyk et al. (2023),
 Delaney et al. (2023), Ogier et al. (2025), and Ogier et al. (2026).
@@ -25,7 +25,7 @@ The Shreve hydraulic potential φ used for routing is
 ```
 
 where *H* is ice thickness, *z_s* is surface elevation, *f* is the flotation
-fraction, and ρᵢ, ρ_w are ice and water density.  At full flotation (*f* = 1)
+fraction, and *ρᵢ*, *ρ_w* are ice and water density.  At full flotation (*f* = 1)
 this is the standard Shreve potential.  The bed elevation is z_b = z_s − H.
 
 Water flows down the gradient of φ, not down the gradient of the bed.

--- a/docs/src/worked-example.md
+++ b/docs/src/worked-example.md
@@ -98,8 +98,10 @@ println("Unresolved pits:            ", length(pits))
 println("Supercooled cells:          ", sum(out.pressmelt.sc_locs))
 println("Max discharge [m³/s]:       ",
         round(maximum(area.total[glacier]), digits=4))
-println("Max lake depth (fixed surf) [m]:  ",
+println("Max lake depth (fixed surf) [m water equivalent]:  ",
         round(maximum(out.lakes.depth_fixed_surface[glacier]), digits=1))
+println("Max lake depth (free surface) [m]:   ",
+        round(maximum(out.lakes.depth_free_surface[glacier]), digits=1))
 ```
 
 **Interpreting the output:**


### PR DESCRIPTION
Basically: 
-added references of Shreve (1972) and Röthlisberger (1972) in the subglacial documentation. 
-printed the `lake_free_depth` and edit the units in the worked example of Unteraar (because I think we use more often the `lakes.depth_free_surface` than the `lakes.depth_fixed_surface`). 